### PR TITLE
Fix the bug caused when no type is specified with a non-string default

### DIFF
--- a/minicli/__init__.py
+++ b/minicli/__init__.py
@@ -53,7 +53,7 @@ def _add_arguments(parser, parameters):
         if param.annotation != param.empty:
             types[name] = param.annotation
         else:
-            types[name] = str
+            types[name] = None
 
     return positionals, vararg, keywords, types
 
@@ -64,6 +64,8 @@ def _get_argument(parsed_args, name, types, vararg=False):
 
     def _convert_type(typehint, value):
         try:
+            if typehint is None:
+                return value
             return typehint(value)
         except ValueError as error:
             sys.stderr.write(str(error))

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -104,3 +104,11 @@ def test_incorrect_string_for_argument():
         command(test_fun, argv=['10.5'])
         print(exc_info)
     return
+
+
+def test_function_with_None_default():
+
+    def test_fun(avar=None):
+        assert avar is None
+
+    command(test_fun)


### PR DESCRIPTION
issue 12

desired behavior is to simply use the default when no value is
provided, else just pass the usual string.
Instead, the default gets cast to a string.

this has been fixed